### PR TITLE
AbstractInstall.php

### DIFF
--- a/src/migrations/AbstractInstall.php
+++ b/src/migrations/AbstractInstall.php
@@ -106,7 +106,7 @@ abstract class AbstractInstall extends Migration
             $this->createTable(LinkRecord::tableName(), [
                 'id' => $this->primaryKey(),
                 'providerId' => $this->integer()->notNull(),
-                'providerUid' => $this->integer()->notNull(),
+                'providerUid' => $this->uid(),
                 'keyChainId' => $this->integer()->notNull(),
                 'dateUpdated' => $this->dateTime()->notNull(),
                 'dateCreated' => $this->dateTime()->notNull(),


### PR DESCRIPTION
Replace the providerUid column type from integer to uid to corresponding to the format of provider uid received on provider assigning key pair.

To fix error SQL (Postgres 11.x) when saving my provider after assigning a key chain pair.