### PR TITLE
Add required types to $allowAnonymous

### DIFF
--- a/src/controllers/messages/AbstractLogoutController.php
+++ b/src/controllers/messages/AbstractLogoutController.php
@@ -24,7 +24,7 @@ use yii\web\HttpException;
 abstract class AbstractLogoutController extends AbstractController implements \flipbox\saml\core\EnsureSAMLPlugin
 {
 
-    protected $allowAnonymous = [
+    protected array|bool|int $allowAnonymous = [
         'actionIndex',
         'actionRequest',
     ];


### PR DESCRIPTION
Error:
{
  "name": "PHP Compile Error",
  "message": "Type of flipbox\\saml\\core\\controllers\\messages\\AbstractLogoutController::$allowAnonymous must be array|int|bool (as in class craft\\web\\Controller)",
  "code": 64,
  "type": "yii\\base\\ErrorException",
  "file": "/var/www/html/vendor/flipboxfactory/saml-core/src/controllers/messages/AbstractLogoutController.php",
  "line": 24,
  "stack-trace": [
    "#0 [internal function]: yii\\base\\ErrorHandler->handleFatalError()",
    "#1 {main}"
  ]
}

Craft 4 introduces types on:
protected array|bool|int $allowAnonymous = self::ALLOW_ANONYMOUS_NEVER;
vendor/craftcms/cms/src/web/Controller.php:57