### PR TITLE
Add UserLogout event for logout requests

### DIFF
--- a/src/events/UserLogout.php
+++ b/src/events/UserLogout.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @copyright  Copyright (c) Flipbox Digital Limited
+ */
+
+namespace flipbox\saml\core\events;
+
+use SAML2\LogoutRequest;
+use yii\base\Event;
+
+/**
+ * Class UserLogout
+ * @package flipbox\saml\core\events
+ */
+class UserLogout extends Event
+{
+
+    /**
+     * @var LogoutRequest
+     */
+    public $request;
+}

--- a/src/services/messages/LogoutRequest.php
+++ b/src/services/messages/LogoutRequest.php
@@ -10,6 +10,7 @@ use craft\base\Component;
 use flipbox\saml\core\models\SettingsInterface;
 use flipbox\saml\core\records\AbstractProvider;
 use flipbox\saml\core\records\AbstractProviderIdentity;
+use flipbox\saml\core\events\UserLogout;
 use SAML2\Constants;
 use SAML2\HTTPRedirect;
 use SAML2\LogoutRequest as SamlLogoutRequest;
@@ -107,12 +108,12 @@ class LogoutRequest extends Component
         /**
          * Kick off event here so people can manipulate this object if needed
          */
-        $event = new Event();
+        $event = new UserLogout();
 
         /**
          * response
          */
-        $event->data = $logout;
+        $event->request = $logout;
         $this->trigger(static::EVENT_AFTER_MESSAGE_CREATED, $event);
 
         return $logout;


### PR DESCRIPTION
This PR adds a `UserLogout` event to allow the logout request object to get passed to any callbacks to the `eventAfterMessageCreated` event in the `LogoutRequest` service.

Fixes https://github.com/flipboxfactory/saml-core/issues/9.

## How to test

Set up the following event callback in a Craft installation that has the [SAML SSO Service Provider plugin](https://github.com/flipboxfactory/saml-sp) enabled. Confirm that the `$logout` variable is a `\SAML2\LogoutRequest` instance rather than null:

```php
\yii\base\Event::on(
  \flipbox\saml\core\services\messages\LogoutRequest::class,
  \flipbox\saml\core\services\messages\LogoutRequest::EVENT_AFTER_MESSAGE_CREATED,
  function (\flipbox\saml\core\events\UserLogout $event) {
    /** @var \SAML2\LogoutRequest */
    $logout = $event->request;
  }
);
```